### PR TITLE
Add access-control-allow-origin header

### DIFF
--- a/helfi_proxy.services.yml
+++ b/helfi_proxy.services.yml
@@ -52,6 +52,11 @@ services:
     tags:
       - { name: event_subscriber }
 
+  helfi_proxy.cors_subscriber:
+    class: Drupal\helfi_proxy\EventSubscriber\CorsResponseSubscriber
+    tags:
+      - { name: event_subscriber }
+
   helfi_proxy.asset.css.optimizer:
     public: false
     class: Drupal\helfi_proxy\Asset\CssOptimizer

--- a/helfi_proxy.services.yml
+++ b/helfi_proxy.services.yml
@@ -3,6 +3,9 @@ parameters:
     - www.hel.fi
     - www-test.hel.fi
     - helfi-proxy.docker.so
+  helfi_proxy.valid_origin_domains:
+    - hel.fi
+    - docker.so
 services:
   helfi_proxy.http_middleware:
     class: Drupal\helfi_proxy\HttpMiddleware\AssetHttpMiddleware
@@ -54,6 +57,8 @@ services:
 
   helfi_proxy.cors_subscriber:
     class: Drupal\helfi_proxy\EventSubscriber\CorsResponseSubscriber
+    arguments:
+      - '%helfi_proxy.valid_origin_domains%'
     tags:
       - { name: event_subscriber }
 

--- a/src/EventSubscriber/CorsResponseSubscriber.php
+++ b/src/EventSubscriber/CorsResponseSubscriber.php
@@ -13,10 +13,16 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 final class CorsResponseSubscriber implements EventSubscriberInterface {
 
-  private const ALLOWED_DOMAINS = [
-    'hel.fi',
-    'docker.so',
-  ];
+  /**
+   * Constructs a new instance.
+   *
+   * @param array $validOriginDomains
+   *   An array of domains.
+   */
+  public function __construct(
+    private array $validOriginDomains
+  ) {
+  }
 
   /**
    * Adds cors headers to a response.
@@ -32,7 +38,7 @@ final class CorsResponseSubscriber implements EventSubscriberInterface {
     }
     $validHost = FALSE;
 
-    foreach (self::ALLOWED_DOMAINS as $domain) {
+    foreach ($this->validOriginDomains as $domain) {
       if ($requestDomain === $domain) {
         $validHost = TRUE;
       }

--- a/src/EventSubscriber/CorsResponseSubscriber.php
+++ b/src/EventSubscriber/CorsResponseSubscriber.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_proxy\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds required CORS headers.
+ */
+final class CorsResponseSubscriber implements EventSubscriberInterface {
+
+  private const ALLOWED_DOMAINS = [
+    'hel.fi',
+    'docker.so',
+  ];
+
+  /**
+   * Adds CORS headers.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The event to respond to.
+   */
+  public function onResponse(ResponseEvent $event) : void {
+    $requestDomain = $event->getRequest()->headers->get('Origin');
+    $validHost = FALSE;
+
+    foreach (self::ALLOWED_DOMAINS as $domain) {
+      if ($requestDomain === $domain) {
+        $validHost = TRUE;
+      }
+
+      if (str_ends_with($requestDomain, '.' . $domain)) {
+        $validHost = TRUE;
+      }
+    }
+    if (!$validHost) {
+      return;
+    }
+
+    $event->getResponse()->headers->add([
+      'Access-Control-Allow-Origin' => $requestDomain,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    $events[KernelEvents::RESPONSE][] = ['onResponse', -100];
+    return $events;
+  }
+
+}

--- a/src/EventSubscriber/CorsResponseSubscriber.php
+++ b/src/EventSubscriber/CorsResponseSubscriber.php
@@ -26,6 +26,10 @@ final class CorsResponseSubscriber implements EventSubscriberInterface {
    */
   public function onResponse(ResponseEvent $event) : void {
     $requestDomain = $event->getRequest()->headers->get('Origin');
+
+    if (!$requestDomain) {
+      return;
+    }
     $validHost = FALSE;
 
     foreach (self::ALLOWED_DOMAINS as $domain) {

--- a/src/EventSubscriber/CorsResponseSubscriber.php
+++ b/src/EventSubscriber/CorsResponseSubscriber.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Adds required CORS headers.
+ * Adds required CORS headers to a response.
  */
 final class CorsResponseSubscriber implements EventSubscriberInterface {
 
@@ -19,7 +19,7 @@ final class CorsResponseSubscriber implements EventSubscriberInterface {
   ];
 
   /**
-   * Adds CORS headers.
+   * Adds cors headers to a response.
    *
    * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
    *   The event to respond to.
@@ -33,6 +33,7 @@ final class CorsResponseSubscriber implements EventSubscriberInterface {
         $validHost = TRUE;
       }
 
+      // Allow subdomains as well.
       if (str_ends_with($requestDomain, '.' . $domain)) {
         $validHost = TRUE;
       }

--- a/tests/src/Kernel/CorsResponseSubscriberTest.php
+++ b/tests/src/Kernel/CorsResponseSubscriberTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_proxy\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests CORS response subscriber.
+ *
+ * @coversDefaultClass \Drupal\helfi_proxy\EventSubscriber\CorsResponseSubscriber
+ * @group helfi_proxy
+ */
+class CorsResponseSubscriberTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'path_alias',
+    'helfi_proxy',
+  ];
+
+  /**
+   * Make sure cors headers are set properly.
+   *
+   * @dataProvider corsTestData
+   */
+  public function testCors(string $domain, bool $expected) : void {
+    $request = Request::create('/', server: [
+      'HTTP_HOST' => 'localhost:8888',
+    ]);
+    $request->headers->set('Origin', $domain);
+    $http_kernel = $this->container->get('http_kernel');
+    /** @var \Symfony\Component\HttpFoundation\Response $response */
+    $response = $http_kernel->handle($request);
+    $this->assertEquals($expected, $response->headers->has('Access-Control-Allow-Origin'));
+  }
+
+  /**
+   * Data provider for testCors().
+   *
+   * @return array[]
+   *   The data.
+   */
+  public function corsTestData() : array {
+    return [
+      ['www.hel.fi', TRUE],
+      ['hel.fi', TRUE],
+      ['docker.so', TRUE],
+      ['helfi-kymp.docker.so', TRUE],
+      ['testdocker.so', FALSE],
+    ];
+  }
+
+}

--- a/tests/src/Kernel/CorsResponseSubscriberTest.php
+++ b/tests/src/Kernel/CorsResponseSubscriberTest.php
@@ -28,7 +28,7 @@ class CorsResponseSubscriberTest extends KernelTestBase {
    *
    * @dataProvider corsTestData
    */
-  public function testCors(string $domain, bool $expected) : void {
+  public function testCors(mixed $domain, bool $expected) : void {
     $request = Request::create('/', server: [
       'HTTP_HOST' => 'localhost:8888',
     ]);
@@ -52,6 +52,7 @@ class CorsResponseSubscriberTest extends KernelTestBase {
       ['docker.so', TRUE],
       ['helfi-kymp.docker.so', TRUE],
       ['testdocker.so', FALSE],
+      [NULL, FALSE],
     ];
   }
 


### PR DESCRIPTION
- `composer require drupal/helfi_proxy:dev-UHF-X-cors`
- `drush cr`

Attempt to request `https://helfi-etusivu.docker.so/fi/api/v1/global-menu` URL from some other instance (kymp or terveys for example) and make sure request does not fail due to CORS. 
