### PR TITLE
UHF-5938 robots debug page entry

### DIFF
--- a/src/Plugin/DebugDataItem/Robots.php
+++ b/src/Plugin/DebugDataItem/Robots.php
@@ -19,7 +19,12 @@ use Psr\Container\ContainerInterface;
  */
 class Robots extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface {
 
-  protected bool $robots_header;
+  /**
+   * Robots header enabled settings value.
+   *
+   * @var bool
+   */
+  protected bool $robotsHeader;
 
   /**
    * {@inheritdoc}
@@ -28,12 +33,12 @@ class Robots extends DebugDataItemPluginBase implements ContainerFactoryPluginIn
     $instance = new static($configuration, $plugin_id, $plugin_definition);
 
     try {
-      $instance->robots_header = (bool) $container->get('config.factory')
+      $instance->robotsHeader = (bool) $container->get('config.factory')
         ->get('helfi_proxy.settings')
         ->get('robots_header_enabled');
     }
     catch (\Exception $e) {
-      $instance->robots_header = FALSE;
+      $instance->robotsHeader = FALSE;
     }
 
     return $instance;
@@ -43,7 +48,7 @@ class Robots extends DebugDataItemPluginBase implements ContainerFactoryPluginIn
    * {@inheritdoc}
    */
   public function collect(): array {
-    $data['DRUPAL_X_ROBOTS_TAG_HEADER'] = $this->robots_header;
+    $data['DRUPAL_X_ROBOTS_TAG_HEADER'] = $this->robotsHeader;
     return $data;
   }
 

--- a/src/Plugin/DebugDataItem/Robots.php
+++ b/src/Plugin/DebugDataItem/Robots.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_proxy\Plugin\DebugDataItem;
+
+use Drupal\helfi_api_base\DebugDataItemPluginBase;
+
+/**
+ * Plugin implementation of the debug_data_item.
+ *
+ * @DebugDataItem(
+ *   id = "robots",
+ *   label = @Translation("Robots"),
+ *   description = @Translation("Robots data")
+ * )
+ */
+class Robots extends DebugDataItemPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function collect(): array {
+    $data['DRUPAL_X_ROBOTS_TAG_HEADER'] = (bool)getenv('DRUPAL_X_ROBOTS_TAG_HEADER');
+    return $data;
+  }
+
+}

--- a/src/Plugin/DebugDataItem/Robots.php
+++ b/src/Plugin/DebugDataItem/Robots.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_proxy\Plugin\DebugDataItem;
 
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\helfi_api_base\DebugDataItemPluginBase;
+use Psr\Container\ContainerInterface;
 
 /**
  * Plugin implementation of the debug_data_item.
@@ -15,13 +17,33 @@ use Drupal\helfi_api_base\DebugDataItemPluginBase;
  *   description = @Translation("Robots data")
  * )
  */
-class Robots extends DebugDataItemPluginBase {
+class Robots extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface {
+
+  protected bool $robots_header;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+
+    try {
+      $instance->robots_header = (bool) $container->get('config.factory')
+        ->get('helfi_proxy.settings')
+        ->get('robots_header_enabled');
+    }
+    catch (\Exception $e) {
+      $instance->robots_header = FALSE;
+    }
+
+    return $instance;
+  }
 
   /**
    * {@inheritdoc}
    */
   public function collect(): array {
-    $data['DRUPAL_X_ROBOTS_TAG_HEADER'] = (bool) getenv('DRUPAL_X_ROBOTS_TAG_HEADER');
+    $data['DRUPAL_X_ROBOTS_TAG_HEADER'] = $this->robots_header;
     return $data;
   }
 

--- a/src/Plugin/DebugDataItem/Robots.php
+++ b/src/Plugin/DebugDataItem/Robots.php
@@ -24,7 +24,7 @@ class Robots extends DebugDataItemPluginBase implements ContainerFactoryPluginIn
    *
    * @var bool
    */
-  protected bool $robotsHeader;
+  protected bool $robotsHeader = FALSE;
 
   /**
    * {@inheritdoc}
@@ -37,8 +37,7 @@ class Robots extends DebugDataItemPluginBase implements ContainerFactoryPluginIn
         ->get('helfi_proxy.settings')
         ->get('robots_header_enabled');
     }
-    catch (\Exception $e) {
-      $instance->robotsHeader = FALSE;
+    catch (\Exception) {
     }
 
     return $instance;

--- a/src/Plugin/DebugDataItem/Robots.php
+++ b/src/Plugin/DebugDataItem/Robots.php
@@ -21,7 +21,7 @@ class Robots extends DebugDataItemPluginBase {
    * {@inheritdoc}
    */
   public function collect(): array {
-    $data['DRUPAL_X_ROBOTS_TAG_HEADER'] = (bool)getenv('DRUPAL_X_ROBOTS_TAG_HEADER');
+    $data['DRUPAL_X_ROBOTS_TAG_HEADER'] = (bool) getenv('DRUPAL_X_ROBOTS_TAG_HEADER');
     return $data;
   }
 

--- a/templates/debug-item--robots.html.twig
+++ b/templates/debug-item--robots.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * To actually show any data from a custom plugin, you *MUST* override this template
+ * with a template called 'debug-item--{{ id }}.html.twig'.
+ *
+ * For example: debug-item--composer.html.twig, where 'composer' is your plugin's ID.
+ *
+ * You can then loop your data with something like this:
+ * {% for item in data.packages %}
+ *    {{ item.name }}
+ *    {{ item.version }}
+ * {% endfor %}
+ *
+ *  Available variables:
+ *  - id: The ID of your plugin
+ *  - label The label of your plugin
+ *  - data:  An array of data returned by your plugin's collect() method.
+ */
+#}
+
+<h2>Robots</h2>
+<table style="width:auto;">
+  <thead>
+  <tr>
+    <th>Key</th>
+    <th>Status</th>
+  </tr>
+  </thead>
+  <tbody>
+  {% for key, value in data %}
+    <tr>
+      <th>
+        {{ key }}
+      </th>
+      <td>
+        <span style="color: {{ color }}">
+         {{ value ? 'TRUE' : 'FALSE' }}
+        </span>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
Added code which allows showing robots header status on debug page

Related PR
https://github.com/City-of-Helsinki/drupal-hdbt-admin/compare/UHF-5938_robots_debug_page_entry