### PR TITLE
UHF-5618: rss feed would not be handled as xml

### DIFF
--- a/src/HttpMiddleware/AssetHttpMiddleware.php
+++ b/src/HttpMiddleware/AssetHttpMiddleware.php
@@ -97,10 +97,12 @@ final class AssetHttpMiddleware implements HttpKernelInterface {
     if (!$response->headers->has('content-type')) {
       return FALSE;
     }
-    return str_starts_with(
-      $response->headers->get('content-type') ?: '',
-      'application/xml',
-    );
+    foreach(['application/xml', 'application/rss+xml'] as $type) {
+      if (str_starts_with($response->headers->get('content-type'), $type)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**

--- a/src/HttpMiddleware/AssetHttpMiddleware.php
+++ b/src/HttpMiddleware/AssetHttpMiddleware.php
@@ -97,7 +97,7 @@ final class AssetHttpMiddleware implements HttpKernelInterface {
     if (!$response->headers->has('content-type')) {
       return FALSE;
     }
-    foreach(['application/xml', 'application/rss+xml'] as $type) {
+    foreach (['application/xml', 'application/rss+xml'] as $type) {
       if (str_starts_with($response->headers->get('content-type'), $type)) {
         return TRUE;
       }

--- a/tests/src/Unit/AssetHttpMiddlewareTest.php
+++ b/tests/src/Unit/AssetHttpMiddlewareTest.php
@@ -69,6 +69,7 @@ class AssetHttpMiddlewareTest extends UnitTestCase {
     return [
       ['application/xml'],
       ['application/xml; charset=utf-8'],
+      ['application/rss+xml; charset=utf-8'],
     ];
   }
 


### PR DESCRIPTION
Missing content type. rss feed would be missing ' </ link >' tag since the response was not handled properly.