### PR TITLE
UHF-7126: Allow non-html values to be processed, UHF-7193: fixed radioactivity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.0', '8.1']
     container:
       image: ghcr.io/city-of-helsinki/drupal-php-docker:${{ matrix.php-versions }}-alpine
 
@@ -83,7 +83,7 @@ jobs:
 
       - name: Create an artifact from test report
         uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
           name: results
           path: |

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -80,7 +80,8 @@ function helfi_proxy_js_settings_alter(
     $service = \Drupal::service('helfi_proxy.active_prefix');
 
     if (!$prefix = $service->getPrefix()) {
-      // Fallback to /en if site has no prefixes configured, like Etusivu for example.
+      // Fallback to /en if site has no prefixes configured, like Etusivu
+      // for example.
       $prefix = '/en';
     }
     $settings['radioactivity']['endpoint'] = sprintf('%s/radioactivity/emit', $prefix);

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -75,6 +75,16 @@ function helfi_proxy_js_settings_alter(
     }
     $settings[$key] = helfi_proxy_absolute_url($settings[$key]);
   }
+  if (isset($settings['radioactivity'])) {
+    /** @var \Drupal\helfi_proxy\ActiveSitePrefix $service */
+    $service = \Drupal::service('helfi_proxy.active_prefix');
+
+    if (!$prefix = $service->getPrefix()) {
+      // Fallback to /en if site has no prefixes configured, like Etusivu for example.
+      $prefix = '/en';
+    }
+    $settings['radioactivity']['endpoint'] = sprintf('%s/radioactivity/emit', $prefix);
+  }
 }
 
 /**

--- a/helfi_proxy.services.yml
+++ b/helfi_proxy.services.yml
@@ -7,6 +7,10 @@ parameters:
     - hel.fi
     - docker.so
 services:
+  helfi_proxy.active_prefix:
+    class: Drupal\helfi_proxy\ActiveSitePrefix
+    arguments: ['@language_manager', '@config.factory']
+
   helfi_proxy.http_middleware:
     class: Drupal\helfi_proxy\HttpMiddleware\AssetHttpMiddleware
     arguments: ['@helfi_proxy.proxy_manager']
@@ -20,7 +24,7 @@ services:
 
   helfi_proxy.path_processor:
     class: Drupal\helfi_proxy\PathProcessor\SitePrefixPathProcessor
-    arguments: ['@config.factory']
+    arguments: ['@helfi_proxy.active_prefix']
     tags:
       # Must be run before PathProcessorFront (200 weight).
       - { name: path_processor_inbound, priority: 201 }
@@ -35,7 +39,7 @@ services:
 
   cache_context.site_prefix:
     class: Drupal\helfi_proxy\Cache\Context\SitePrefixCacheContext
-    arguments: ['@config.factory']
+    arguments: ['@helfi_proxy.active_prefix']
     tags:
       - { name: cache.context }
 

--- a/src/ActiveSitePrefix.php
+++ b/src/ActiveSitePrefix.php
@@ -65,7 +65,7 @@ final class ActiveSitePrefix implements RefinableCacheableDependencyInterface {
 
     if (!$langcode) {
       $langcode = $this->languageManager
-        ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+        ->getCurrentLanguage(LanguageInterface::TYPE_URL)
         ->getId();
     }
     return $prefixes[$langcode] ?? NULL;

--- a/src/ActiveSitePrefix.php
+++ b/src/ActiveSitePrefix.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_proxy;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Cache\RefinableCacheableDependencyTrait;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+
+/**
+ * A service to figure out currently active site prefix.
+ */
+final class ActiveSitePrefix implements RefinableCacheableDependencyInterface {
+
+  use RefinableCacheableDependencyTrait;
+
+  /**
+   * The configuration.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  private ImmutableConfig $config;
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
+  public function __construct(
+    private LanguageManagerInterface $languageManager,
+    ConfigFactoryInterface $configFactory
+  ) {
+    $this->config = $configFactory->get('helfi_proxy.settings');
+    $this->addCacheableDependency($this->config);
+  }
+
+  /**
+   * Gets the site prefixes.
+   *
+   * @return array
+   *   The prefixes.
+   */
+  public function getPrefixes() : array {
+    if (!$prefixes = $this->config->get(ProxyManagerInterface::PREFIXES)) {
+      return [];
+    }
+    return $prefixes;
+  }
+
+  /**
+   * Gets the currently active site prefix.
+   *
+   * @return string|null
+   *   The active prefix.
+   */
+  public function getPrefix() : ? string {
+    $prefixes = $this->getPrefixes();
+    $langCode = $this->languageManager
+      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+      ->getId();
+    return $prefixes[$langCode] ?? NULL;
+  }
+
+}

--- a/src/ActiveSitePrefix.php
+++ b/src/ActiveSitePrefix.php
@@ -60,12 +60,15 @@ final class ActiveSitePrefix implements RefinableCacheableDependencyInterface {
    * @return string|null
    *   The active prefix.
    */
-  public function getPrefix() : ? string {
+  public function getPrefix(string $langcode = NULL) : ? string {
     $prefixes = $this->getPrefixes();
-    $langCode = $this->languageManager
-      ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
-      ->getId();
-    return $prefixes[$langCode] ?? NULL;
+
+    if (!$langcode) {
+      $langcode = $this->languageManager
+        ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+        ->getId();
+    }
+    return $prefixes[$langcode] ?? NULL;
   }
 
 }

--- a/src/Cache/Context/SitePrefixCacheContext.php
+++ b/src/Cache/Context/SitePrefixCacheContext.php
@@ -6,8 +6,8 @@ namespace Drupal\helfi_proxy\Cache\Context;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Cache\Context\CalculatedCacheContextInterface;
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\helfi_proxy\ActiveSitePrefix;
 
 /**
  * Defines the SitePrefixCacheContext service, for "per site prefix" caching.
@@ -17,34 +17,26 @@ use Drupal\Core\Config\ImmutableConfig;
 final class SitePrefixCacheContext implements CalculatedCacheContextInterface {
 
   /**
-   * The config.
-   *
-   * @var \Drupal\Core\Config\ImmutableConfig
-   */
-  private ImmutableConfig $config;
-
-  /**
    * Constructs a new instance.
    *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
-   *   The config factory.
+   * @param \Drupal\helfi_proxy\ActiveSitePrefix $sitePrefix
+   *   The active site prefix service.
    */
-  public function __construct(ConfigFactoryInterface $configFactory) {
-    $this->config = $configFactory->get('helfi_proxy.settings');
+  public function __construct(private ActiveSitePrefix $sitePrefix) {
   }
 
   /**
    * {@inheritdoc}
    */
-  public static function getLabel() {
-    return t('Site prefix');
+  public static function getLabel() : string {
+    return (string) new TranslatableMarkup('Site prefix');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getContext($prefix = NULL) {
-    $prefixes = $this->config->get('prefixes') ?? [];
+  public function getContext($prefix = NULL) : string {
+    $prefixes = $this->sitePrefix->getPrefixes();
 
     if ($prefix === NULL) {
       return implode(',', $prefixes);

--- a/src/Controller/FrontController.php
+++ b/src/Controller/FrontController.php
@@ -6,6 +6,7 @@ namespace Drupal\helfi_proxy\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\helfi_proxy\ProxyManagerInterface;
 
 /**
  * Empty front page controller.
@@ -36,7 +37,7 @@ final class FrontController extends ControllerBase {
    *   The title.
    */
   public function title() : string {
-    if ($title = $this->config('helfi_proxy.settings')->get('front_page_title')) {
+    if ($title = $this->config('helfi_proxy.settings')->get(ProxyManagerInterface::FRONT_PAGE_TITLE)) {
       return $title;
     }
     return (string) $this->t('Front');

--- a/src/HttpMiddleware/AssetHttpMiddleware.php
+++ b/src/HttpMiddleware/AssetHttpMiddleware.php
@@ -58,7 +58,7 @@ final class AssetHttpMiddleware implements HttpKernelInterface {
       $hasChanges = TRUE;
 
       $content[$key]['data'] = $this->proxyManager
-        ->processHtml($value['data'], $request);
+        ->process($value['data'], $request);
     }
     return $hasChanges ? json_encode($content) : NULL;
   }
@@ -138,7 +138,7 @@ final class AssetHttpMiddleware implements HttpKernelInterface {
     }
 
     $content = $this->proxyManager
-      ->processHtml($content, $request);
+      ->process($content, $request);
 
     return $response->setContent($content);
   }

--- a/src/HttpMiddleware/AssetHttpMiddleware.php
+++ b/src/HttpMiddleware/AssetHttpMiddleware.php
@@ -58,7 +58,7 @@ final class AssetHttpMiddleware implements HttpKernelInterface {
       $hasChanges = TRUE;
 
       $content[$key]['data'] = $this->proxyManager
-        ->process($value['data'], $request);
+        ->processHtml($value['data'], $request);
     }
     return $hasChanges ? json_encode($content) : NULL;
   }
@@ -138,7 +138,7 @@ final class AssetHttpMiddleware implements HttpKernelInterface {
     }
 
     $content = $this->proxyManager
-      ->process($content, $request);
+      ->processHtml($content, $request);
 
     return $response->setContent($content);
   }

--- a/src/PathProcessor/SitePrefixPathProcessor.php
+++ b/src/PathProcessor/SitePrefixPathProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_proxy\PathProcessor;
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\PathProcessor\InboundPathProcessorInterface;
 use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
 use Drupal\Core\Render\BubbleableMetadata;
@@ -33,7 +34,7 @@ final class SitePrefixPathProcessor implements OutboundPathProcessorInterface, I
     $parts = explode('/', trim($path, '/'));
     $prefix = array_shift($parts);
 
-    if ($prefix === $this->sitePrefix->getPrefix()) {
+    if (in_array($prefix, $this->sitePrefix->getPrefixes())) {
       $path = '/' . implode('/', $parts);
     }
 
@@ -53,7 +54,14 @@ final class SitePrefixPathProcessor implements OutboundPathProcessorInterface, I
     if (!isset($options['language'])) {
       return $path;
     }
-    $prefix = $this->sitePrefix->getPrefix();
+    $language = $options['language'];
+
+    if ($options['language'] instanceof LanguageInterface) {
+      $language = $options['language']->getId();
+    }
+    // Use already resolved language to figure out active prefix
+    // since it might be different from content language.
+    $prefix = $this->sitePrefix->getPrefix($language);
 
     $bubbleable_metadata?->addCacheContexts(['site_prefix:' . $prefix])
       ->addCacheableDependency($this->sitePrefix);

--- a/src/ProxyManager.php
+++ b/src/ProxyManager.php
@@ -6,10 +6,10 @@ namespace Drupal\helfi_proxy;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\helfi_proxy\Selector\AbsoluteUriAttributeSelector;
-use Drupal\helfi_proxy\Selector\AttributeSelector;
 use Drupal\helfi_proxy\Selector\MultiValueAttributeSelector;
 use Drupal\helfi_proxy\Selector\SelectorInterface;
 use Drupal\helfi_proxy\Selector\SelectorRepositoryTrait;
+use Drupal\helfi_proxy\Selector\StringValue;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -49,7 +49,7 @@ final class ProxyManager implements ProxyManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function processHtml(string $html, Request $request, array $selectors = []) : string {
+  public function processHtml(string $html, Request $request = NULL, array $selectors = []) : string {
     $dom = new \DOMDocument();
     $previousXmlErrorBehavior = libxml_use_internal_errors(TRUE);
     $encoding = '<?xml encoding="utf-8" ?>';
@@ -66,8 +66,8 @@ final class ProxyManager implements ProxyManagerInterface {
         $value = $this
           ->getAttributeValue(
             $selector,
-            $request,
             $row->getAttribute($selector->attribute),
+            $request
           );
 
         if (!$value) {
@@ -86,11 +86,14 @@ final class ProxyManager implements ProxyManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function processValue(string $value, Request $request, array $selectors = []) : string {
+  public function processValue(string $value, Request $request = NULL, array $selectors = []) : string {
     $value = trim($value);
 
+    if (!$selectors) {
+      $selectors[] = new StringValue();
+    }
     foreach ($selectors as $selector) {
-      $value = $this->getAttributeValue($selector, $request, $value);
+      $value = $this->getAttributeValue($selector, $value, $request);
     }
     return $value;
   }
@@ -100,15 +103,15 @@ final class ProxyManager implements ProxyManagerInterface {
    *
    * @param \Drupal\helfi_proxy\Selector\SelectorInterface $selector
    *   The selector.
-   * @param \Symfony\Component\HttpFoundation\Request $request
-   *   The request.
    * @param string|null $value
    *   The value.
+   * @param null|\Symfony\Component\HttpFoundation\Request $request
+   *   The request.
    *
    * @return string|null
    *   The attribute value.
    */
-  private function getAttributeValue(SelectorInterface $selector, Request $request, ?string $value) : ? string {
+  private function getAttributeValue(SelectorInterface $selector, ?string $value, Request $request = NULL) : ? string {
     // Skip if value is being served from CDN already.
     if (!$value || $this->isCdnAddress($value)) {
       return $value;
@@ -117,6 +120,9 @@ final class ProxyManager implements ProxyManagerInterface {
     // Certain elements might be absolute URLs already (such as og:image:url).
     // Make sure locally hosted files are always served from correct domain.
     if ($selector instanceof AbsoluteUriAttributeSelector) {
+      if (!$request) {
+        throw new \LogicException('Missing required Request $request.');
+      }
       $parts = parse_url($value);
 
       if (empty($parts['path'])) {

--- a/src/ProxyManager.php
+++ b/src/ProxyManager.php
@@ -8,6 +8,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\helfi_proxy\Selector\AbsoluteUriAttributeSelector;
 use Drupal\helfi_proxy\Selector\AttributeSelector;
 use Drupal\helfi_proxy\Selector\MultiValueAttributeSelector;
+use Drupal\helfi_proxy\Selector\SelectorInterface;
 use Drupal\helfi_proxy\Selector\SelectorRepositoryTrait;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -97,7 +98,7 @@ final class ProxyManager implements ProxyManagerInterface {
   /**
    * Gets the attribute value.
    *
-   * @param \Drupal\helfi_proxy\Selector\AttributeSelector $selector
+   * @param \Drupal\helfi_proxy\Selector\SelectorInterface $selector
    *   The selector.
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The request.
@@ -107,7 +108,7 @@ final class ProxyManager implements ProxyManagerInterface {
    * @return string|null
    *   The attribute value.
    */
-  private function getAttributeValue(AttributeSelector $selector, Request $request, ?string $value) : ? string {
+  private function getAttributeValue(SelectorInterface $selector, Request $request, ?string $value) : ? string {
     // Skip if value is being served from CDN already.
     if (!$value || $this->isCdnAddress($value)) {
       return $value;

--- a/src/ProxyManagerInterface.php
+++ b/src/ProxyManagerInterface.php
@@ -30,7 +30,7 @@ interface ProxyManagerInterface {
   /**
    * Manipulates the given attributes to have correct values.
    *
-   * @param string $html
+   * @param string $content
    *   The html to manipulate.
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The request.
@@ -40,7 +40,7 @@ interface ProxyManagerInterface {
    * @return \Symfony\Component\HttpFoundation\Response
    *   The manipulated response.
    */
-  public function processHtml(string $html, Request $request, array $selectors = []) : string;
+  public function process(string $content, Request $request, array $selectors = []) : string;
 
   /**
    * Whether the proxy is configured or not.

--- a/src/ProxyManagerInterface.php
+++ b/src/ProxyManagerInterface.php
@@ -32,7 +32,7 @@ interface ProxyManagerInterface {
    *
    * @param string $html
    *   The html to manipulate.
-   * @param \Symfony\Component\HttpFoundation\Request $request
+   * @param null|\Symfony\Component\HttpFoundation\Request $request
    *   The request.
    * @param array $selectors
    *   The selectors.
@@ -40,14 +40,14 @@ interface ProxyManagerInterface {
    * @return \Symfony\Component\HttpFoundation\Response
    *   The manipulated response.
    */
-  public function processHtml(string $html, Request $request, array $selectors = []) : string;
+  public function processHtml(string $html, Request $request = NULL, array $selectors = []) : string;
 
   /**
    * Processes a string value.
    *
    * @param string $value
    *   The value.
-   * @param \Symfony\Component\HttpFoundation\Request $request
+   * @param null|\Symfony\Component\HttpFoundation\Request $request
    *   The request.
    * @param array $selectors
    *   The selectors.
@@ -55,7 +55,7 @@ interface ProxyManagerInterface {
    * @return string
    *   The processed value.
    */
-  public function processValue(string $value, Request $request, array $selectors = []) : string;
+  public function processValue(string $value, Request $request = NULL, array $selectors = []) : string;
 
   /**
    * Whether the proxy is configured or not.

--- a/src/ProxyManagerInterface.php
+++ b/src/ProxyManagerInterface.php
@@ -30,7 +30,7 @@ interface ProxyManagerInterface {
   /**
    * Manipulates the given attributes to have correct values.
    *
-   * @param string $content
+   * @param string $html
    *   The html to manipulate.
    * @param \Symfony\Component\HttpFoundation\Request $request
    *   The request.
@@ -40,7 +40,22 @@ interface ProxyManagerInterface {
    * @return \Symfony\Component\HttpFoundation\Response
    *   The manipulated response.
    */
-  public function process(string $content, Request $request, array $selectors = []) : string;
+  public function processHtml(string $html, Request $request, array $selectors = []) : string;
+
+  /**
+   * Processes a string value.
+   *
+   * @param string $value
+   *   The value.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   * @param array $selectors
+   *   The selectors.
+   *
+   * @return string
+   *   The processed value.
+   */
+  public function processValue(string $value, Request $request, array $selectors = []) : string;
 
   /**
    * Whether the proxy is configured or not.

--- a/src/Selector/SelectorRepositoryTrait.php
+++ b/src/Selector/SelectorRepositoryTrait.php
@@ -16,6 +16,7 @@ trait SelectorRepositoryTrait {
    *   The default selectors.
    */
   protected function getDefaultSelectors() : array {
+    // @todo Refactor these to PHP attributes.
     return [
       new AttributeSelector('//input[@type="image"]', 'src'),
       new MultiValueAttributeSelector('//source', 'srcset', ', '),

--- a/src/Selector/StringValue.php
+++ b/src/Selector/StringValue.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_proxy\Selector;
+
+/**
+ * Defines a string value selector.
+ */
+final class StringValue implements SelectorInterface {
+}

--- a/tests/src/Functional/SitePrefixPathProcessorTest.php
+++ b/tests/src/Functional/SitePrefixPathProcessorTest.php
@@ -25,10 +25,12 @@ class SitePrefixPathProcessorTest extends SitePrefixTestBase {
 
       $this->drupalGet($this->node->toUrl('canonical', ['language' => $language]));
       $this->assertSession()->addressEquals("/{$langPrefix}prefix-$langcode/node/" . $this->node->id());
+      $this->assertSession()->statusCodeEquals(200);
       $this->assertCacheContext('site_prefix:prefix-' . $langcode);
 
       $this->drupalGet('/admin/content', ['language' => $language]);
       $this->assertSession()->addressEquals("/{$langPrefix}prefix-$langcode/admin/content");
+      $this->assertSession()->statusCodeEquals(200);
 
       // Admin page should have currrently active and en cache contexts.
       foreach ([$langcode, 'en'] as $context) {

--- a/tests/src/Kernel/ActiveSitePrefixTest.php
+++ b/tests/src/Kernel/ActiveSitePrefixTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_proxy\Kernel;
+
+use Drupal\helfi_proxy\ActiveSitePrefix;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests Active site prefix service.
+ *
+ * @coversDefaultClass \Drupal\helfi_proxy\ActiveSitePrefix
+ * @group helfi_proxy
+ */
+class ActiveSitePrefixTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'path_alias',
+    'language',
+    'helfi_proxy',
+  ];
+
+  /**
+   * Gets the service.
+   *
+   * @return \Drupal\helfi_proxy\ActiveSitePrefix
+   *   The service.
+   */
+  private function getSut() : ActiveSitePrefix {
+    $this->container->get('kernel')->rebuildContainer();
+    return $this->container->get('helfi_proxy.active_prefix');
+  }
+
+  /**
+   * Tests ::getPrefix() without proxy paths.
+   *
+   * @covers ::getPrefix
+   * @covers ::getPrefixes
+   */
+  public function testEmptyPrefix() : void {
+    $this->assertEquals(NULL, $this->getSut()->getPrefix());
+    $this->assertEquals([], $this->getSut()->getPrefixes());
+  }
+
+  /**
+   * Tests ::getPrefix with proxy paths.
+   *
+   * @covers ::getPrefix
+   * @covers ::getPrefixes
+   */
+  public function testPrefix() : void {
+    $prefixes = [
+      'sv' => 'prefix-sv',
+      'en' => 'prefix-en',
+      'fi' => 'prefix-fi',
+    ];
+    $this->config('helfi_proxy.settings')
+      ->set('prefixes', $prefixes)
+      ->save();
+
+    $this->assertEquals('prefix-en', $this->getSut()->getPrefix());
+    // Make sure we can override active language by providing langcode
+    // as an argument.
+    $this->assertEquals('prefix-fi', $this->getSut()->getPrefix('fi'));
+    // Make sure langcode stays intact after fetching it again without
+    // langcode argument.
+    $this->assertEquals('prefix-en', $this->getSut()->getPrefix());
+
+    $this->assertEquals($prefixes, $this->getSut()->getPrefixes());
+  }
+
+}

--- a/tests/src/Kernel/ProxyManagerTest.php
+++ b/tests/src/Kernel/ProxyManagerTest.php
@@ -10,6 +10,7 @@ use Drupal\helfi_proxy\ProxyTrait;
 use Drupal\helfi_proxy\Selector\AbsoluteUriAttributeSelector;
 use Drupal\helfi_proxy\Selector\AttributeSelector;
 use Drupal\helfi_proxy\Selector\MultiValueAttributeSelector;
+use Drupal\helfi_proxy\Selector\StringValue;
 use Drupal\KernelTests\KernelTestBase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -201,6 +202,26 @@ class ProxyManagerTest extends KernelTestBase {
     $processed = $this->proxyManager()
       ->processHtml($html, $request, [new AttributeSelector('//script', 'src')]);
     $this->assertEquals($expected, $processed);
+  }
+
+  /**
+   * Tests string value processing.
+   *
+   * @covers ::processValue
+   * @covers ::getAttributeValue
+   * @covers ::getDefaultSelectors
+   * @covers ::isAbsoluteUri
+   * @covers ::addAssetPath
+   * @covers ::__construct
+   */
+  public function testStringValueSelector() : void {
+    $this->setAssetPath('test-assets');
+    $request = $this->createRequest();
+
+    $processed = $this->proxyManager()->processValue('/core/modules/system/test.js', $request, [
+      new StringValue(),
+    ]);
+    $this->assertEquals('/test-assets/core/modules/system/test.js', $processed);
   }
 
   /**

--- a/tests/src/Kernel/ProxyManagerTest.php
+++ b/tests/src/Kernel/ProxyManagerTest.php
@@ -184,7 +184,7 @@ class ProxyManagerTest extends KernelTestBase {
   /**
    * Tests script tag attribute value.
    *
-   * @covers ::processHtml
+   * @covers ::process
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isAbsoluteUri
@@ -199,14 +199,14 @@ class ProxyManagerTest extends KernelTestBase {
     $html = $this->createHtmlTag('script', ['src' => '/core/modules/system/test.js']);
 
     $processed = $this->proxyManager()
-      ->processHtml($html, $request, [new AttributeSelector('//script', 'src')]);
+      ->process($html, $request, [new AttributeSelector('//script', 'src')]);
     $this->assertEquals($expected, $processed);
   }
 
   /**
    * Tests AbsoluteUriAttributeSelector() object.
    *
-   * @covers ::processHtml
+   * @covers ::process
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isAbsoluteUri
@@ -240,7 +240,7 @@ class ProxyManagerTest extends KernelTestBase {
 
       $this->assertEquals(
         $expected,
-        $this->proxyManager()->processHtml($html, $request, [$attributeSelector])
+        $this->proxyManager()->process($html, $request, [$attributeSelector])
       );
 
       // Make sure the domain is converted to correct one.
@@ -251,7 +251,7 @@ class ProxyManagerTest extends KernelTestBase {
 
       $this->assertEquals(
         $expected,
-        $this->proxyManager()->processHtml($html, $request, [$attributeSelector])
+        $this->proxyManager()->process($html, $request, [$attributeSelector])
       );
     }
   }
@@ -259,7 +259,7 @@ class ProxyManagerTest extends KernelTestBase {
   /**
    * Tests blob storage url when blob storage name is set.
    *
-   * @covers ::processHtml
+   * @covers ::process
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isCdnAddress
@@ -280,7 +280,7 @@ class ProxyManagerTest extends KernelTestBase {
     // is set.
     $this->assertEquals(
       $html,
-      $this->proxyManager()->processHtml($html, $request, [
+      $this->proxyManager()->process($html, $request, [
         new AbsoluteUriAttributeSelector('//meta[@property="og:image:url"]', 'content'),
       ])
     );
@@ -289,7 +289,7 @@ class ProxyManagerTest extends KernelTestBase {
   /**
    * Tests blob storage url when STAGE_FILE_PROXY_ORIGIN is set.
    *
-   * @covers ::processHtml
+   * @covers ::process
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isCdnAddress
@@ -310,7 +310,7 @@ class ProxyManagerTest extends KernelTestBase {
 
     $this->assertEquals(
       $html,
-      $this->proxyManager()->processHtml($html, $request, [
+      $this->proxyManager()->process($html, $request, [
         new AbsoluteUriAttributeSelector('//meta[@property="og:image:url"]', 'content'),
       ])
     );
@@ -319,7 +319,7 @@ class ProxyManagerTest extends KernelTestBase {
   /**
    * Tests source srcset.
    *
-   * @covers ::processHtml
+   * @covers ::process
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isCdnAddress
@@ -351,7 +351,7 @@ class ProxyManagerTest extends KernelTestBase {
 
     $this->assertEquals(
       $expected,
-      $this->proxyManager()->processHtml($html, $request, [
+      $this->proxyManager()->process($html, $request, [
         new MultiValueAttributeSelector('//source', 'srcset', ', '),
       ])
     );

--- a/tests/src/Kernel/ProxyManagerTest.php
+++ b/tests/src/Kernel/ProxyManagerTest.php
@@ -10,7 +10,6 @@ use Drupal\helfi_proxy\ProxyTrait;
 use Drupal\helfi_proxy\Selector\AbsoluteUriAttributeSelector;
 use Drupal\helfi_proxy\Selector\AttributeSelector;
 use Drupal\helfi_proxy\Selector\MultiValueAttributeSelector;
-use Drupal\helfi_proxy\Selector\StringValue;
 use Drupal\KernelTests\KernelTestBase;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/tests/src/Kernel/ProxyManagerTest.php
+++ b/tests/src/Kernel/ProxyManagerTest.php
@@ -216,11 +216,8 @@ class ProxyManagerTest extends KernelTestBase {
    */
   public function testStringValueSelector() : void {
     $this->setAssetPath('test-assets');
-    $request = $this->createRequest();
 
-    $processed = $this->proxyManager()->processValue('/core/modules/system/test.js', $request, [
-      new StringValue(),
-    ]);
+    $processed = $this->proxyManager()->processValue('/core/modules/system/test.js');
     $this->assertEquals('/test-assets/core/modules/system/test.js', $processed);
   }
 

--- a/tests/src/Kernel/ProxyManagerTest.php
+++ b/tests/src/Kernel/ProxyManagerTest.php
@@ -184,7 +184,7 @@ class ProxyManagerTest extends KernelTestBase {
   /**
    * Tests script tag attribute value.
    *
-   * @covers ::process
+   * @covers ::processHtml
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isAbsoluteUri
@@ -199,14 +199,14 @@ class ProxyManagerTest extends KernelTestBase {
     $html = $this->createHtmlTag('script', ['src' => '/core/modules/system/test.js']);
 
     $processed = $this->proxyManager()
-      ->process($html, $request, [new AttributeSelector('//script', 'src')]);
+      ->processHtml($html, $request, [new AttributeSelector('//script', 'src')]);
     $this->assertEquals($expected, $processed);
   }
 
   /**
    * Tests AbsoluteUriAttributeSelector() object.
    *
-   * @covers ::process
+   * @covers ::processHtml
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isAbsoluteUri
@@ -240,7 +240,7 @@ class ProxyManagerTest extends KernelTestBase {
 
       $this->assertEquals(
         $expected,
-        $this->proxyManager()->process($html, $request, [$attributeSelector])
+        $this->proxyManager()->processHtml($html, $request, [$attributeSelector])
       );
 
       // Make sure the domain is converted to correct one.
@@ -251,7 +251,7 @@ class ProxyManagerTest extends KernelTestBase {
 
       $this->assertEquals(
         $expected,
-        $this->proxyManager()->process($html, $request, [$attributeSelector])
+        $this->proxyManager()->processHtml($html, $request, [$attributeSelector])
       );
     }
   }
@@ -259,7 +259,7 @@ class ProxyManagerTest extends KernelTestBase {
   /**
    * Tests blob storage url when blob storage name is set.
    *
-   * @covers ::process
+   * @covers ::processHtml
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isCdnAddress
@@ -280,7 +280,7 @@ class ProxyManagerTest extends KernelTestBase {
     // is set.
     $this->assertEquals(
       $html,
-      $this->proxyManager()->process($html, $request, [
+      $this->proxyManager()->processHtml($html, $request, [
         new AbsoluteUriAttributeSelector('//meta[@property="og:image:url"]', 'content'),
       ])
     );
@@ -289,7 +289,7 @@ class ProxyManagerTest extends KernelTestBase {
   /**
    * Tests blob storage url when STAGE_FILE_PROXY_ORIGIN is set.
    *
-   * @covers ::process
+   * @covers ::processHtml
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isCdnAddress
@@ -310,7 +310,7 @@ class ProxyManagerTest extends KernelTestBase {
 
     $this->assertEquals(
       $html,
-      $this->proxyManager()->process($html, $request, [
+      $this->proxyManager()->processHtml($html, $request, [
         new AbsoluteUriAttributeSelector('//meta[@property="og:image:url"]', 'content'),
       ])
     );
@@ -319,7 +319,7 @@ class ProxyManagerTest extends KernelTestBase {
   /**
    * Tests source srcset.
    *
-   * @covers ::process
+   * @covers ::processHtml
    * @covers ::getAttributeValue
    * @covers ::getDefaultSelectors
    * @covers ::isCdnAddress
@@ -351,7 +351,7 @@ class ProxyManagerTest extends KernelTestBase {
 
     $this->assertEquals(
       $expected,
-      $this->proxyManager()->process($html, $request, [
+      $this->proxyManager()->processHtml($html, $request, [
         new MultiValueAttributeSelector('//source', 'srcset', ', '),
       ])
     );


### PR DESCRIPTION
To test this, run:

- `composer require drupal/helfi_proxy:dev-UHF-7126`
- `drush cr`

Make sure etusivu calls radioactivity emit path with language prefix: 
![image](https://user-images.githubusercontent.com/771113/196875500-11bf7fda-b5b6-4d2e-870c-c5c2a872b8a1.png)
