### PR TITLE
UHF-4826: Automatic return URL detection for Tunnistamo return URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ env:
   DRUPAL_CORE_VERSION: 9.3.x
   SYMFONY_DEPRECATIONS_HELPER: disabled
   BROWSERTEST_OUTPUT_DIRECTORY: 'sites/simpletest'
+  OPTIONAL_DEPENDENCIES: drupal/helfi_tunnistamo drupal/redirect
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -52,6 +53,8 @@ jobs:
           composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
           composer require --dev donatj/mock-webserver
           composer require --dev "drupal/coder"
+          # Install defined optional dependencies.
+          composer require $OPTIONAL_DEPENDENCIES -W
 
       - name: Install Drupal
         run: |

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,11 @@
         "drupal/purge": "^3.0",
         "drupal/varnish_purge": "^2.1",
         "drupal/helfi_api_base": "*",
-        "drupal/redirect": "^1.0",
         "ext-libxml": "*",
         "ext-dom": "*"
+    },
+    "conflict": {
+        "drupal/helfi_tunnistamo": "<=2.2.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",

--- a/helfi_proxy.services.yml
+++ b/helfi_proxy.services.yml
@@ -39,12 +39,6 @@ services:
     tags:
       - { name: cache.context }
 
-  helfi_proxy.tunnistamo_redirect_subscriber:
-    class: Drupal\helfi_proxy\EventSubscriber\TunnistamoRedirectUrlSubscriber
-    arguments: ['@helfi_proxy.proxy_manager']
-    tags:
-      - { name: event_subscriber }
-
   helfi_proxy.proxy_manager:
     class: Drupal\helfi_proxy\ProxyManager
     arguments: ['@config.factory']

--- a/src/EventSubscriber/TunnistamoRedirectUrlSubscriber.php
+++ b/src/EventSubscriber/TunnistamoRedirectUrlSubscriber.php
@@ -4,43 +4,59 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_proxy\EventSubscriber;
 
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Url;
+use Drupal\helfi_proxy\ActiveSitePrefix;
 use Drupal\helfi_proxy\ProxyManagerInterface;
 use Drupal\helfi_tunnistamo\Event\RedirectUrlEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Tunnistamo redirect url subscriber.
- *
- * @phpcs:ignore
- * @deprecated in helfi_proxy:2.1.2 and is removed from helfi_proxy:3.0.0.
+ * Tunnistamo return url subscriber.
  */
 final class TunnistamoRedirectUrlSubscriber implements EventSubscriberInterface {
 
   /**
    * Constructs a new instance.
    *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager.
    * @param \Drupal\helfi_proxy\ProxyManagerInterface $proxyManager
    *   The proxy manager.
+   * @param \Drupal\helfi_proxy\ActiveSitePrefix $prefix
+   *   The active site prefix service.
    */
   public function __construct(
-    private ProxyManagerInterface $proxyManager
+    private LanguageManagerInterface $languageManager,
+    private ProxyManagerInterface $proxyManager,
+    private ActiveSitePrefix $prefix,
   ) {
   }
 
   /**
-   * Responds to tunnistamo redirect url event.
+   * Responds to Tunnistamo redirect url event.
    *
    * @param \Drupal\helfi_tunnistamo\Event\RedirectUrlEvent $event
    *   Response event.
    */
   public function onRedirectUrlEvent(RedirectUrlEvent $event) : void {
-    if (!$url = $this->proxyManager->getConfig(ProxyManagerInterface::TUNNISTAMO_RETURN_URL)) {
+    $returnUrl = $this->proxyManager->getConfig(ProxyManagerInterface::TUNNISTAMO_RETURN_URL);
+
+    $uriOptions = [];
+    // Fallback to automatically constructed return url if return url is not
+    // defined.
+    if (!$returnUrl && $activePrefix = $this->prefix->getPrefix('fi')) {
+      $uriOptions['language'] = $this->languageManager->getLanguage('fi');
+      // Tunnistamo return URL is always configured to use /fi prefix.
+      $returnUrl = sprintf('/fi/%s/openid-connect/%s', $activePrefix, $event->getClient()->getPluginId());
+    }
+
+    if (!$returnUrl) {
       return;
     }
 
     try {
-      $event->setRedirectUrl(Url::fromUserInput($url)->setAbsolute());
+      $event->setRedirectUrl(Url::fromUserInput($returnUrl, $uriOptions)->setAbsolute());
     }
     catch (\InvalidArgumentException $e) {
     }
@@ -50,11 +66,8 @@ final class TunnistamoRedirectUrlSubscriber implements EventSubscriberInterface 
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() : array {
-    if (!class_exists('\Drupal\helfi_tunnistamo\Event\RedirectUrlEvent')) {
-      return [];
-    }
     return [
-      'Drupal\helfi_tunnistamo\Event\RedirectUrlEvent' => ['onRedirectUrlEvent'],
+      RedirectUrlEvent::class => ['onRedirectUrlEvent'],
     ];
   }
 

--- a/src/HelfiProxyServiceProvider.php
+++ b/src/HelfiProxyServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_proxy;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\helfi_proxy\EventSubscriber\TunnistamoRedirectUrlSubscriber;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Registers services for non-required modules.
+ */
+class HelfiProxyServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    // We cannot use the module handler as the container is not yet compiled.
+    // @see \Drupal\Core\DrupalKernel::compileContainer()
+    $modules = $container->getParameter('container.modules');
+
+    if (isset($modules['helfi_tunnistamo'])) {
+      $container->register('helfi_proxy.tunnistamo_redirect_subscriber', TunnistamoRedirectUrlSubscriber::class)
+        ->addTag('event_subscriber')
+        ->addArgument(new Reference('language_manager'))
+        ->addArgument(new Reference('helfi_proxy.proxy_manager'))
+        ->addArgument(new Reference('helfi_proxy.active_prefix'));
+    }
+  }
+
+}

--- a/src/ProxyManagerInterface.php
+++ b/src/ProxyManagerInterface.php
@@ -18,13 +18,6 @@ interface ProxyManagerInterface {
   public const DEFAULT_PROXY_DOMAIN = 'default_proxy_domain';
   public const SESSION_SUFFIX = 'session_suffix';
   public const ROBOTS_HEADER_ENABLED = 'robots_header_enabled';
-
-  /**
-   * The tunnistamo return url config name.
-   *
-   * @phpcs:ignore
-   * @deprecated in helfi_proxy:2.1.2 and is removed from helfi_proxy:3.0.0.
-   */
   public const TUNNISTAMO_RETURN_URL = 'tunnistamo_return_url';
 
   /**

--- a/tests/src/Kernel/TunnistamoRedirectUrlSubscriberTest.php
+++ b/tests/src/Kernel/TunnistamoRedirectUrlSubscriberTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_proxy\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\helfi_proxy\ProxyManagerInterface;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\openid_connect\Entity\OpenIDConnectClientEntity;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests Tunnistamo redirect url subscriber.
+ *
+ * @coversDefaultClass \Drupal\helfi_proxy\EventSubscriber\TunnistamoRedirectUrlSubscriber
+ * @group helfi_proxy
+ */
+class TunnistamoRedirectUrlSubscriberTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'language',
+    'openid_connect',
+    'externalauth',
+    'user',
+    'file',
+    'helfi_api_base',
+    'path_alias',
+    'helfi_tunnistamo',
+    'helfi_proxy',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+
+    // Core's KernelTestBase removes service_collector tags from
+    // path_alias.path_processor service. We need to add them back
+    // to test them.
+    // @see \Drupal\KernelTests\KernelTestBase::register().
+    $container->getDefinition('path_alias.path_processor')
+      ->addTag('path_processor_inbound')
+      ->addTag('path_processor_outbound');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() : void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('path_alias');
+    User::create([
+      'name' => '',
+      'uid' => 0,
+    ])->save();
+    $this->installConfig(['language', 'helfi_tunnistamo']);
+
+    foreach (['fi', 'sv'] as $langcode) {
+      ConfigurableLanguage::createFromLangcode($langcode)->save();
+    }
+    $this->config('helfi_proxy.settings')
+      ->set('prefixes', [
+        'sv' => 'prefix-sv',
+        'en' => 'prefix-en',
+        'fi' => 'prefix-fi',
+      ])
+      ->save();
+
+    $this->config('language.negotiation')
+      ->set('url.prefixes', ['en' => 'en', 'fi' => 'fi', 'sv' => 'sv'])
+      ->save();
+
+    \Drupal::service('kernel')->rebuildContainer();
+  }
+
+  /**
+   * Gets the Tunnistamo redirect url.
+   *
+   * @return string
+   *   The redirect url.
+   */
+  private function getRedirectUri() : string {
+    $client = OpenIDConnectClientEntity::load('tunnistamo')->getPlugin();
+    $url = $client->authorize()->getTargetUrl();
+    parse_str(parse_url($url, PHP_URL_QUERY), $query);
+
+    return $query['redirect_uri'];
+  }
+
+  /**
+   * Make sure manually configured URL is preferred over automatic detection.
+   */
+  public function testReturnUrl() : void {
+    $this->config('helfi_proxy.settings')
+      ->set(ProxyManagerInterface::TUNNISTAMO_RETURN_URL, '/fi/jotain/openid-connect/tunnistamo')
+      ->save();
+    $this->assertEquals('http://localhost/fi/jotain/openid-connect/tunnistamo', $this->getRedirectUri());
+  }
+
+  /**
+   * Make sure automatically determine return URL is used as fallback.
+   */
+  public function testFallbackReturnUrl() : void {
+    $this->assertEquals('http://localhost/fi/prefix-fi/openid-connect/tunnistamo', $this->getRedirectUri());
+  }
+
+}

--- a/tests/src/Unit/RedirectResponseSubscriberTest.php
+++ b/tests/src/Unit/RedirectResponseSubscriberTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
- * Tests asset middleware.
+ * Tests redirect response subscriber.
  *
  * @coversDefaultClass \Drupal\helfi_proxy\EventSubscriber\RedirectResponseSubscriber
  * @group helfi_proxy


### PR DESCRIPTION
- `composer require drupal/helfi_tunnistamo:dev-UHF-4826`
- `composer require drupal/helfi_proxy:dev-UHF-4826`
- `drush cr`

How to test:

- Make sure you have no `$config['helfi_proxy.settings']['tunnistamo_return_url']`  overrides in your `local.settings.php` file
- Open `/user/login` page and click `Log in with Tunnistamo` and make sure `redirect_uri` query parameter contains instance's Finnish proxy path. For example, KYMP should match `/fi/kaupunkiymparisto-ja-liikenne/openid-connect/tunnistamo`

Related PRs:
- https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo/pull/16