### PR TITLE
Uhf 8103 sitemap urls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "drupal/coder": "^8.3",
-        "phpspec/prophecy-phpunit": "^2"
+        "phpspec/prophecy-phpunit": "^2",
+        "drupal/simple_sitemap": "^4.1"
     }
 }

--- a/helfi_proxy.info.yml
+++ b/helfi_proxy.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^8 || ^9
 dependencies:
   - path_alias
   - redirect
+  - drupal:helfi_api_base

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -91,17 +91,19 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
     return;
   }
 
-  $userPreferredAdminLangcode = \drupal::currentUser()->getPreferredAdminLangcode(FALSE) ?? 'fi';
+  $userPreferredAdminLangcode = \drupal::currentUser()->getPreferredAdminLangcode(FALSE) ?: 'fi';
 
   $config = \Drupal::configFactory()->get('simple_sitemap.settings')?->get('base_url');
   if ($config) {
     $pattern = "/\/$userPreferredAdminLangcode\/.*?\//";
     foreach ($links as $key => &$link) {
       $url = &$link['url'];
+      $x = preg_replace($pattern, '/', $url, 1);
       $link['url'] = preg_replace($pattern, '/', $url, 1);
+
       $alternateUrls = &$link['alternate_urls'];
       foreach ($alternateUrls as $alternateurl_key => $alternateUrl) {
-        $link['alternate_urls'][$alternateurl_key] = preg_replace($pattern, '/', $alternateUrl, 1);
+        //$link['alternate_urls'][$alternateurl_key] = preg_replace($pattern, '/', $alternateUrl, 1);
       }
       $links[$key] = $link;
     }

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -82,3 +82,18 @@ function helfi_proxy_page_attachments_alter(array &$attachments) {
     $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];
   }
 }
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant) {
+  foreach($links as $key => &$link) {
+    $url =& $link['url'];
+    $link['url'] = preg_replace('/\/fi\/.*?\//','/', $url, 1);
+    $alternateUrls =& $link['alternate_urls'];
+    foreach($alternateUrls as $key => &$alternateUrl) {
+        $link['alternate_urls'][$key] = preg_replace('/\/fi\/.*?\//','/', $alternateUrl, 1);
+    }
+    $links[$key] = $link;
+  }
+}

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -100,7 +100,7 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
       $url = &$link['url'];
       $link['url'] = preg_replace($pattern, '/', $url, 1);
       $alternateUrls = &$link['alternate_urls'];
-      foreach($alternateUrls as $alternateurl_key => &$alternateUrl) {
+      foreach ($alternateUrls as $alternateurl_key => $alternateUrl) {
         $link['alternate_urls'][$alternateurl_key] = preg_replace($pattern, '/', $alternateUrl, 1);
       }
       $links[$key] = $link;
@@ -108,4 +108,3 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
   }
 
 }
-

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -88,11 +88,11 @@ function helfi_proxy_page_attachments_alter(array &$attachments) {
  */
 function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant) {
   foreach ($links as $key => &$link) {
-    $url =& $link['url'];
+    $url = &$link['url'];
     $link['url'] = preg_replace('/\/fi\/.*?\//', '/', $url, 1);
-    $alternateUrls =& $link['alternate_urls'];
-    foreach ($alternateUrls as $key => &$alternateUrl) {
-      $link['alternate_urls'][$key] = preg_replace('/\/fi\/.*?\//', '/', $alternateUrl, 1);
+    $alternateUrls = &$link['alternate_urls'];
+    foreach ($alternateUrls as $alternateurl_key => $alternateUrl) {
+      $link['alternate_urls'][$alternateurl_key] = preg_replace('/\/fi\/.*?\//', '/', $alternateUrl, 1);
     }
     $links[$key] = $link;
   }

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -27,7 +27,6 @@ function helfi_proxy_module_implements_alter(&$implementations, $hook) : void {
  * Implements hook_file_url_alter().
  */
 function helfi_proxy_file_url_alter(&$uri) : void {
-  $conf = \Drupal::configFactory()->getEditable('simple_sitemap.settings');
   /** @var \Drupal\helfi_proxy\ProxyManagerInterface $service */
   $service = \Drupal::service('helfi_proxy.proxy_manager');
   $uri = $service->processPath($uri);

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -27,6 +27,7 @@ function helfi_proxy_module_implements_alter(&$implementations, $hook) : void {
  * Implements hook_file_url_alter().
  */
 function helfi_proxy_file_url_alter(&$uri) : void {
+  $conf = \Drupal::configFactory()->getEditable('simple_sitemap.settings');
   /** @var \Drupal\helfi_proxy\ProxyManagerInterface $service */
   $service = \Drupal::service('helfi_proxy.proxy_manager');
   $uri = $service->processPath($uri);

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -87,13 +87,25 @@ function helfi_proxy_page_attachments_alter(array &$attachments) {
  * Implements hook_page_attachments_alter().
  */
 function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant) {
-  foreach ($links as $key => &$link) {
-    $url = &$link['url'];
-    $link['url'] = preg_replace('/\/fi\/.*?\//', '/', $url, 1);
-    $alternateUrls = &$link['alternate_urls'];
-    foreach ($alternateUrls as $alternateurl_key => $alternateUrl) {
-      $link['alternate_urls'][$alternateurl_key] = preg_replace('/\/fi\/.*?\//', '/', $alternateUrl, 1);
-    }
-    $links[$key] = $link;
+  if ($sitemap_variant->getOriginalId() != 'default') {
+    return;
   }
+
+  $userPreferredAdminLangcode = \drupal::currentUser()->getPreferredAdminLangcode(FALSE) ?? 'fi';
+
+  $config = \Drupal::configFactory()->get('simple_sitemap.settings')?->get('base_url');
+  if ($config) {
+    $pattern = "/\/$userPreferredAdminLangcode\/.*?\//";
+    foreach ($links as $key => &$link) {
+      $url = &$link['url'];
+      $link['url'] = preg_replace($pattern, '/', $url, 1);
+      $alternateUrls = &$link['alternate_urls'];
+      foreach($alternateUrls as $alternateurl_key => &$alternateUrl) {
+        $link['alternate_urls'][$alternateurl_key] = preg_replace($pattern, '/', $alternateUrl, 1);
+      }
+      $links[$key] = $link;
+    }
+  }
+
 }
+

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -87,12 +87,12 @@ function helfi_proxy_page_attachments_alter(array &$attachments) {
  * Implements hook_page_attachments_alter().
  */
 function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant) {
-  foreach($links as $key => &$link) {
+  foreach ($links as $key => &$link) {
     $url =& $link['url'];
-    $link['url'] = preg_replace('/\/fi\/.*?\//','/', $url, 1);
+    $link['url'] = preg_replace('/\/fi\/.*?\//', '/', $url, 1);
     $alternateUrls =& $link['alternate_urls'];
     foreach($alternateUrls as $key => &$alternateUrl) {
-        $link['alternate_urls'][$key] = preg_replace('/\/fi\/.*?\//','/', $alternateUrl, 1);
+      $link['alternate_urls'][$key] = preg_replace('/\/fi\/.*?\//', '/', $alternateUrl, 1);
     }
     $links[$key] = $link;
   }

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -91,7 +91,7 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
     $url =& $link['url'];
     $link['url'] = preg_replace('/\/fi\/.*?\//', '/', $url, 1);
     $alternateUrls =& $link['alternate_urls'];
-    foreach($alternateUrls as $key => &$alternateUrl) {
+    foreach ($alternateUrls as $key => &$alternateUrl) {
       $link['alternate_urls'][$key] = preg_replace('/\/fi\/.*?\//', '/', $alternateUrl, 1);
     }
     $links[$key] = $link;

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -98,12 +98,10 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
     $pattern = "/\/$userPreferredAdminLangcode\/.*?\//";
     foreach ($links as $key => &$link) {
       $url = &$link['url'];
-      $x = preg_replace($pattern, '/', $url, 1);
       $link['url'] = preg_replace($pattern, '/', $url, 1);
-
       $alternateUrls = &$link['alternate_urls'];
       foreach ($alternateUrls as $alternateurl_key => $alternateUrl) {
-        //$link['alternate_urls'][$alternateurl_key] = preg_replace($pattern, '/', $alternateUrl, 1);
+        $link['alternate_urls'][$alternateurl_key] = preg_replace($pattern, '/', $alternateUrl, 1);
       }
       $links[$key] = $link;
     }

--- a/src/Config/SitemapPathOverride.php
+++ b/src/Config/SitemapPathOverride.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_proxy\Config;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\helfi_proxy\ActiveSitePrefix;
 use Drupal\helfi_proxy\ProxyManagerInterface;
 
@@ -18,14 +19,14 @@ class SitemapPathOverride implements ConfigFactoryOverrideInterface {
   /**
    * Constructs a new instance.
    *
-   * @param \Drupal\helfi_proxy\ProxyManagerInterface $proxyManager
-   *   The proxy manager.
    * @param \Drupal\helfi_proxy\ActiveSitePrefix $prefix
    *   The active site prefix service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager.
    */
   public function __construct(
-    private ProxyManagerInterface $proxyManager,
     private ActiveSitePrefix $prefix,
+    private LanguageManagerInterface $languageManager,
   ) {
   }
 
@@ -37,8 +38,8 @@ class SitemapPathOverride implements ConfigFactoryOverrideInterface {
 
     if (in_array('simple_sitemap.settings', $names)) {
       $url = \Drupal::request()->getSchemeAndHttpHost();
-      $prefix = $this->prefix->getPrefix('fi');
-      $langcode = 'fi';
+      $langcode = $this->languageManager->getCurrentLanguage()->getId();
+      $prefix = $this->prefix->getPrefix($langcode);
       $baseUrl = sprintf('%s/%s/%s', $url, $langcode, $prefix);
       $overrides['simple_sitemap.settings']['base_url'] = $baseUrl;
     }

--- a/src/Config/SitemapPathOverride.php
+++ b/src/Config/SitemapPathOverride.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_proxy\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\helfi_proxy\ActiveSitePrefix;
+use Drupal\helfi_proxy\ProxyManagerInterface;
+
+/**
+* Override sitemap path dynamically.
+*/
+class SitemapPathOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\helfi_proxy\ProxyManagerInterface $proxyManager
+   *   The proxy manager.
+   * @param \Drupal\helfi_proxy\ActiveSitePrefix $prefix
+   *   The active site prefix service.
+   */
+  public function __construct(
+    private ProxyManagerInterface $proxyManager,
+    private ActiveSitePrefix $prefix,
+  ) {
+  }
+
+  /**
+  * {@inheritdoc}
+  */
+  public function loadOverrides($names): array {
+    $overrides = [];
+
+    if (in_array('simple_sitemap.settings', $names)) {
+      $url = \Drupal::request()->getSchemeAndHttpHost();
+      $prefix = $this->prefix->getPrefix('fi');
+      $langcode = 'fi';
+      $baseUrl = sprintf('%s/%s/%s', $url, $langcode, $prefix);
+      $overrides['simple_sitemap.settings']['base_url'] = $baseUrl;
+    }
+
+    return $overrides;
+  }
+
+  /**
+  * {@inheritdoc}
+  */
+  public function getCacheSuffix() {
+    return 'SitemapPathOverride';
+  }
+
+  /**
+  * {@inheritdoc}
+  */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+  * {@inheritdoc}
+  */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/src/Config/SitemapPathOverride.php
+++ b/src/Config/SitemapPathOverride.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_proxy\Config;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Http\RequestStack;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\helfi_proxy\ActiveSitePrefix;
 use Drupal\helfi_proxy\ProxyManagerInterface;
@@ -27,6 +28,7 @@ class SitemapPathOverride implements ConfigFactoryOverrideInterface {
   public function __construct(
     private ActiveSitePrefix $prefix,
     private LanguageManagerInterface $languageManager,
+    private RequestStack $requestStack,
   ) {
   }
 
@@ -35,9 +37,13 @@ class SitemapPathOverride implements ConfigFactoryOverrideInterface {
   */
   public function loadOverrides($names): array {
     $overrides = [];
+    $url = $this->requestStack->getCurrentRequest()?->getSchemeAndHttpHost();
+
+    if (!$url) {
+      return $overrides;
+    }
 
     if (in_array('simple_sitemap.settings', $names)) {
-      $url = \Drupal::request()->getSchemeAndHttpHost();
       $langcode = $this->languageManager->getCurrentLanguage()->getId();
       $prefix = $this->prefix->getPrefix($langcode);
       $baseUrl = sprintf('%s/%s/%s', $url, $langcode, $prefix);

--- a/src/HelfiProxyServiceProvider.php
+++ b/src/HelfiProxyServiceProvider.php
@@ -6,6 +6,7 @@ namespace Drupal\helfi_proxy;
 
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\helfi_proxy\Config\SitemapPathOverride;
 use Drupal\helfi_proxy\EventSubscriber\TunnistamoRedirectUrlSubscriber;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -29,6 +30,14 @@ class HelfiProxyServiceProvider extends ServiceProviderBase {
         ->addArgument(new Reference('helfi_proxy.proxy_manager'))
         ->addArgument(new Reference('helfi_proxy.active_prefix'));
     }
+
+    if (isset($modules['simple_sitemap'])) {
+      $container->register('helfi_proxy.sitemap_path_override', SitemapPathOverride::class)
+        ->addTag('config.factory.override')
+        ->addArgument(new Reference('helfi_proxy.proxy_manager'))
+        ->addArgument(new Reference('helfi_proxy.active_prefix'));
+    }
+
   }
 
 }

--- a/src/HelfiProxyServiceProvider.php
+++ b/src/HelfiProxyServiceProvider.php
@@ -35,7 +35,8 @@ class HelfiProxyServiceProvider extends ServiceProviderBase {
       $container->register('helfi_proxy.sitemap_path_override', SitemapPathOverride::class)
         ->addTag('config.factory.override')
         ->addArgument(new Reference('helfi_proxy.active_prefix'))
-        ->addArgument(new Reference('language_manager'));
+        ->addArgument(new Reference('language_manager'))
+        ->addArgument(new Reference('request_stack'));
     }
 
   }

--- a/src/HelfiProxyServiceProvider.php
+++ b/src/HelfiProxyServiceProvider.php
@@ -34,8 +34,8 @@ class HelfiProxyServiceProvider extends ServiceProviderBase {
     if (isset($modules['simple_sitemap'])) {
       $container->register('helfi_proxy.sitemap_path_override', SitemapPathOverride::class)
         ->addTag('config.factory.override')
-        ->addArgument(new Reference('helfi_proxy.proxy_manager'))
-        ->addArgument(new Reference('helfi_proxy.active_prefix'));
+        ->addArgument(new Reference('helfi_proxy.active_prefix'))
+        ->addArgument(new Reference('language_manager'));
     }
 
   }


### PR DESCRIPTION
# [UHF-8103](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8103)
Enhance simple sitemap url generation in certain cases

## What was done
Dynamically set simple_sitemap baseurl config override if module is installed.

## How to install

* Make sure your instance is up and running on dev branch.
* Make sure the site has simple_sitemap installed & enabled (all 9 instances has it )
* Run `composer require drupal/helfi_proxy:dev-UHF-8103_sitemap_urls`
* Run `drush cr`

## How to test

* Reload any page after cache clear
* Run inside container `drush php:eval "echo json_encode(\Drupal::service('config.factory')->get('simple_sitemap.settings')->get('base_url'));"`
* The command should print "{project.docker.so}/{langcode}/{site-prefix}"
 

[UHF-8103]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ