### PR TITLE
UHF-8390: removed core 8, added 10 to requirement

### DIFF
--- a/helfi_proxy.info.yml
+++ b/helfi_proxy.info.yml
@@ -1,8 +1,7 @@
 name: HELfi Proxy
 type: module
 package: Custom
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - path_alias
   - redirect


### PR DESCRIPTION
Updated version requirement

How to test:

No need to test.