### PR TITLE
UHF-8837: Remove pages with X-Robots-Tag: noindex from sitemap

### DIFF
--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Asset\AttachedAssetsInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\helfi_proxy\ProxyManagerInterface;
 
 /**
  * Implements hook_module_implements_alter().
@@ -81,4 +82,39 @@ function helfi_proxy_page_attachments_alter(array &$attachments) {
     ];
     $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];
   }
+}
+
+/**
+ * Implements hook_simple_sitemap_links_alter().
+ */
+function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant) {
+  /** @var \Drupal\Core\Config\ImmutableConfig $config */
+  $config = \Drupal::service('config.factory')->get('helfi_proxy.settings');
+
+  if (!$paths = implode("\n", $config->get(ProxyManagerInterface::ROBOTS_PATHS) ?? [])) {
+    return;
+  }
+
+  /** @var \Drupal\helfi_api_base\Environment\Environment $environment */
+  $environment = \Drupal::service('helfi_api_base.environment_resolver')->getActiveEnvironment();
+
+  /** @var \Drupal\Core\Path\PathMatcherInterface $pathMatcher */
+  $pathMatcher = \Drupal::service('path.matcher');
+
+  // helfi_proxy module sets "X-Robots-Tag: noindex" header for configured
+  // paths. These url should not be included in the sitemap.xml file.
+  foreach ($links as $key => $link) {
+    $baseUrl = $environment->getUrl($link['langcode']);
+    $url = $link['url'];
+
+    if (str_starts_with($url, $baseUrl)) {
+      $path = substr($url, strlen($baseUrl));
+
+      // Remove matched paths from sitemap.xml file.
+      if ($pathMatcher->matchPath($path, $paths)) {
+        unset($links[$key]);
+      }
+    }
+  }
+
 }

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -98,7 +98,8 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
   try {
     /** @var \Drupal\helfi_api_base\Environment\Environment $environment */
     $environment = \Drupal::service('helfi_api_base.environment_resolver')->getActiveEnvironment();
-  } catch (\InvalidArgumentException) {
+  }
+  catch (\InvalidArgumentException) {
     return;
   }
 
@@ -110,7 +111,8 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
   foreach ($links as $key => $link) {
     try {
       $baseUrl = $environment->getUrl($link['langcode']);
-    } catch (\InvalidArgumentException) {
+    }
+    catch (\InvalidArgumentException) {
       // Base url not found for given langcode.
       continue;
     }

--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -95,8 +95,12 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
     return;
   }
 
-  /** @var \Drupal\helfi_api_base\Environment\Environment $environment */
-  $environment = \Drupal::service('helfi_api_base.environment_resolver')->getActiveEnvironment();
+  try {
+    /** @var \Drupal\helfi_api_base\Environment\Environment $environment */
+    $environment = \Drupal::service('helfi_api_base.environment_resolver')->getActiveEnvironment();
+  } catch (\InvalidArgumentException) {
+    return;
+  }
 
   /** @var \Drupal\Core\Path\PathMatcherInterface $pathMatcher */
   $pathMatcher = \Drupal::service('path.matcher');
@@ -104,7 +108,13 @@ function helfi_proxy_simple_sitemap_links_alter(array &$links, $sitemap_variant)
   // helfi_proxy module sets "X-Robots-Tag: noindex" header for configured
   // paths. These url should not be included in the sitemap.xml file.
   foreach ($links as $key => $link) {
-    $baseUrl = $environment->getUrl($link['langcode']);
+    try {
+      $baseUrl = $environment->getUrl($link['langcode']);
+    } catch (\InvalidArgumentException) {
+      // Base url not found for given langcode.
+      continue;
+    }
+
     $url = $link['url'];
 
     if (str_starts_with($url, $baseUrl)) {


### PR DESCRIPTION
# [UHF-8837](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8837)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Helfi proxy module adds `X-Robots-Tag: noindex` to some configured pages. This change removes these pages from `sitemap.xml`.

## How to install

* Make sure strategia instance is up and running on dev branch.
  * ```
    make fresh
    ```
  * Check that [/sisallonhallinta/sivujen-rakentaminen-drupalissa/sivupohjat/laskeutumissivu/paaosion](https://strategia.docker.so/fi/paatoksenteko-ja-hallinto/sisallonhallinta/sivujen-rakentaminen-drupalissa/sivupohjat/laskeutumissivu/paaosion) has `X-Robots-Tag: noindex` header and it is included in [sitemap.xml](https://strategia.docker.so/fi/paatoksenteko-ja-hallinto/sitemap.xml).
* Install
  ```
  composer require drupal/helfi_proxy:dev-UHF-8837-remove-noindex-pages-from-sitemap
  ```
* Regenerate sitemap.xml
  ```
  drush simple-sitemap:generate
  ```

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that [/sisallonhallinta/sivujen-rakentaminen-drupalissa/sivupohjat/laskeutumissivu/paaosion](https://strategia.docker.so/fi/paatoksenteko-ja-hallinto/sisallonhallinta/sivujen-rakentaminen-drupalissa/sivupohjat/laskeutumissivu/paaosion) is no longer included in [sitemap.xml](https://strategia.docker.so/fi/paatoksenteko-ja-hallinto/sitemap.xml).
* [ ] Check that code follows our standards

[UHF-8837]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ