### PR TITLE
UHF-8255 Remove email from contact section that is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,5 +155,3 @@ See [City-of-Helsinki/drupal-helfi-local-proxy](https://github.com/City-of-Helsi
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)
-
-Mail: `drupal@hel.fi`


### PR DESCRIPTION
Check the README that the email drupal@hel.fi is no longer in there.