### PR TITLE
UHF-9448: Add entity id metatag

### DIFF
--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -71,16 +71,22 @@ function helfi_proxy_page_attachments_alter(array &$attachments) {
 
   $entity = !empty($entities) ? reset($entities) : NULL;
   if ($entity) {
-    $tag_name = 'helfi_content_type';
-
-    $helfi_content_type = [
-      '#tag' => 'meta',
-      '#attributes' => [
-        'name' => $tag_name,
-        'content' => $entity->bundle(),
-      ],
+    $tags = [
+      'helfi_content_type' => $entity->bundle(),
+      'helfi_content_id' => $entity->id(),
     ];
-    $attachments['#attached']['html_head'][] = [$helfi_content_type, $tag_name];
+
+    foreach ($tags as $tag_name => $content) {
+      $tag = [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => $tag_name,
+          'content' => $content,
+        ],
+      ];
+
+      $attachments['#attached']['html_head'][] = [$tag, $tag_name];
+    }
   }
 }
 

--- a/tests/src/Functional/CustomMetatagTest.php
+++ b/tests/src/Functional/CustomMetatagTest.php
@@ -50,12 +50,15 @@ class CustomMetatagTest extends BrowserTestBase {
   }
 
   /**
-   * Test that custom header metatag is set on page correctly.
+   * Test that custom header metatags are set correctly.
    */
   public function testMetatag() : void {
     $this->drupalGet($this->node->toUrl('canonical'));
     $this->assertSession()
       ->elementAttributeContains('css', 'meta[name="helfi_content_type"]', 'content', 'page');
+
+    $this->assertSession()
+      ->elementAttributeContains('css', 'meta[name="helfi_content_id"]', 'content', (string) $this->node->id());
 
     $this->drupalGet('<front>');
     $this->assertSession()
@@ -63,6 +66,8 @@ class CustomMetatagTest extends BrowserTestBase {
 
     $this->assertSession()
       ->elementNotExists('css', 'meta[name="helfi_content_type"]');
+    $this->assertSession()
+      ->elementNotExists('css', 'meta[name="helfi_content_id"]');
   }
 
 }


### PR DESCRIPTION
# How to install
- `make fresh`
- `composer require drupal/helfi_tpr:dev-UHF-9448-entity-id-metatag`

# How to test
- [x] Check that the new <meta> tag is present.