### PR TITLE
UHF-9448: Add class="elastic" attribute to metatags

### DIFF
--- a/helfi_proxy.module
+++ b/helfi_proxy.module
@@ -82,6 +82,7 @@ function helfi_proxy_page_attachments_alter(array &$attachments) {
         '#attributes' => [
           'name' => $tag_name,
           'content' => $content,
+          'class' => 'elastic',
         ],
       ];
 

--- a/tests/src/Functional/CustomMetatagTest.php
+++ b/tests/src/Functional/CustomMetatagTest.php
@@ -50,24 +50,32 @@ class CustomMetatagTest extends BrowserTestBase {
   }
 
   /**
+   * Assert element attributes.
+   */
+  private function assertAttributes(string $selector, array $attributes): void {
+    foreach ($attributes as $attribute => $content) {
+      $this->assertSession()->elementAttributeContains('css', $selector, $attribute, $content);
+    }
+  }
+
+  /**
    * Test that custom header metatags are set correctly.
    */
   public function testMetatag() : void {
     $this->drupalGet($this->node->toUrl('canonical'));
-    $this->assertSession()
-      ->elementAttributeContains('css', 'meta[name="helfi_content_type"]', 'content', 'page');
-
-    $this->assertSession()
-      ->elementAttributeContains('css', 'meta[name="helfi_content_id"]', 'content', (string) $this->node->id());
+    $this->assertAttributes('meta[name="helfi_content_type"]', [
+      'content' => 'page',
+      'class' => 'elastic',
+    ]);
+    $this->assertAttributes('meta[name="helfi_content_id"]', [
+      'content' => (string) $this->node->id(),
+      'class' => 'elastic',
+    ]);
 
     $this->drupalGet('<front>');
-    $this->assertSession()
-      ->statusCodeEquals(200);
-
-    $this->assertSession()
-      ->elementNotExists('css', 'meta[name="helfi_content_type"]');
-    $this->assertSession()
-      ->elementNotExists('css', 'meta[name="helfi_content_id"]');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->elementNotExists('css', 'meta[name="helfi_content_type"]');
+    $this->assertSession()->elementNotExists('css', 'meta[name="helfi_content_id"]');
   }
 
 }


### PR DESCRIPTION
# [UHF-9448](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9448)

## What was done
- Add missing class="elastic" attribute to metatags.

## How to test
- `composer require drupal/helfi_proxy:dev-UHF-9448-entity-id-metatag`
- make drush-cr
- Run in JS console: `document.querySelectorAll('.elastic')`. It should find two metatags.

## Related
- #67 

[UHF-9448]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ