### PR TITLE
Move COOKIE_LIFETIME to proxy module

### DIFF
--- a/src/SessionConfiguration.php
+++ b/src/SessionConfiguration.php
@@ -21,6 +21,11 @@ final class SessionConfiguration extends CoreSessionConfiguration {
   use ProxyTrait;
 
   /**
+   * Default cookie lifetime (36 hours).
+   */
+  public const COOKIE_LIFETIME = 129600;
+
+  /**
    * Constructs a new instance.
    *
    * @param \Drupal\helfi_proxy\ProxyManagerInterface $proxyManager
@@ -32,6 +37,8 @@ final class SessionConfiguration extends CoreSessionConfiguration {
     private ProxyManagerInterface $proxyManager,
     #[Autowire('%session.storage.options%')] array $options,
   ) {
+    $options['cookie_lifetime'] = self::COOKIE_LIFETIME;
+
     parent::__construct($options);
   }
 

--- a/tests/src/Kernel/SessionConfigurationTest.php
+++ b/tests/src/Kernel/SessionConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\helfi_proxy\Kernel;
 
 use Drupal\Core\Session\SessionConfigurationInterface;
+use Drupal\helfi_proxy\SessionConfiguration;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\helfi_proxy\ProxyManagerInterface;
 use Drupal\helfi_proxy\ProxyTrait;
@@ -76,6 +77,7 @@ class SessionConfigurationTest extends KernelTestBase {
 
     $options = $this->configuration->getOptions($this->requestStack->getCurrentRequest());
     $this->assertTrue(str_ends_with($options['name'], 'testdev'));
+    $this->assertEquals(SessionConfiguration::COOKIE_LIFETIME, $options['cookie_lifetime']);
   }
 
   /**


### PR DESCRIPTION
## What was done

 - Service had two decorators that were conflicting, see https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo/pull/52

## How to test

-  Log in using any account and make sure the session expires in 36 hours